### PR TITLE
Cleanups for unpronounceable password generation:

### DIFF
--- a/Text/Password.php
+++ b/Text/Password.php
@@ -459,7 +459,7 @@ class Text_Password {
         $GLOBALS['_Text_Password_NumberOfPossibleCharacters'] = $v_count + $c_count;
 
         for ($i = 0; $i < $length; $i++) {
-            $retVal .= $c[$this->_rand(0, $c_count-1)] . $v[$this->_rand(0, $v_count-1)];
+            $retVal .= $c[self::_rand(0, $c_count-1)] . $v[self::_rand(0, $v_count-1)];
         }
 
         return substr($retVal, 0, $length);
@@ -531,7 +531,7 @@ class Text_Password {
         // contains at least 1 character from each class.
         foreach ($chars as $possibleChars) {
             // Get a random character from the character class.
-            $randomCharIndex = $this->_rand(0, strlen($possibleChars) - 1);
+            $randomCharIndex = self::_rand(0, strlen($possibleChars) - 1);
             $randomChar = $possibleChars[$randomCharIndex];
 
             // Get a random insertion position in the current password
@@ -552,12 +552,12 @@ class Text_Password {
         // Insert random chars until the password is long enough.
         while (strlen($password) < $length) {
             // Get a random character from the possible characters.
-            $randomCharIndex = $this->_rand(0, strlen($allPossibleChars) - 1);
+            $randomCharIndex = self::_rand(0, strlen($allPossibleChars) - 1);
             $randomChar = $allPossibleChars[$randomCharIndex];
 
             // Get a random insertion position in the current password
             // value.
-            $randomPosition = $this->_rand(0, strlen($password) - 1);
+            $randomPosition = self::_rand(0, strlen($password) - 1);
 
             // Insert the new character in the current password value.
             $password = substr($password, 0, $randomPosition)

--- a/Text/Password.php
+++ b/Text/Password.php
@@ -536,7 +536,7 @@ class Text_Password {
 
             // Get a random insertion position in the current password
             // value.
-            $randomPosition = rand(0, strlen($password) - 1);
+            $randomPosition = self::_rand(0, strlen($password) - 1);
 
             // Insert the new character in the current password value.
             $password = substr($password, 0, $randomPosition)

--- a/Text/Password.php
+++ b/Text/Password.php
@@ -536,7 +536,7 @@ class Text_Password {
 
             // Get a random insertion position in the current password
             // value.
-            $randomPosition = self::_rand(0, strlen($password) - 1);
+            $randomPosition = self::_rand(0, max(strlen($password) - 1, 0));
 
             // Insert the new character in the current password value.
             $password = substr($password, 0, $randomPosition)
@@ -557,7 +557,7 @@ class Text_Password {
 
             // Get a random insertion position in the current password
             // value.
-            $randomPosition = self::_rand(0, strlen($password) - 1);
+            $randomPosition = self::_rand(0, max(strlen($password) - 1, 0));
 
             // Insert the new character in the current password value.
             $password = substr($password, 0, $randomPosition)

--- a/tests/Text_Password_Test.php
+++ b/tests/Text_Password_Test.php
@@ -39,7 +39,7 @@ class Text_Password_Test extends PHPUnit_Framework_TestCase {
         $password = $this->subject->create(15);
         $this->assertTrue(strlen($password) == 15);
     }
-    
+
     function testCreateMultiple()
     {
         $passwords = $this->subject->createMultiple(3);
@@ -49,7 +49,7 @@ class Text_Password_Test extends PHPUnit_Framework_TestCase {
     function testCreateMultipleWithLength()
     {
         $passwords = $this->subject->createMultiple(3, 15);
-        $this->_testCreateMultiple($passwords, 3, 15);        
+        $this->_testCreateMultiple($passwords, 3, 15);
     }
 
     function testCreateNumericWithLength()
@@ -70,6 +70,28 @@ class Text_Password_Test extends PHPUnit_Framework_TestCase {
         $password = $this->subject->create(8, 'unpronounceable', 'alphabetic');
 
         $this->assertRegExp("/^[a-z]{8}$/i", $password);
+    }
+
+    function testCreateUnpronouncableWithAllClasses()
+    {
+        $password = $this->subject->create(8, 'unpronounceable', '');
+        $this->assertRegExp('/^[a-z0-9_#@%&]{8}$/i', $password);
+
+        // Make sure all character classes are used at least once.
+        $this->assertRegExp('/[a-z]/', $password);
+        $this->assertRegExp('/[A-Z]/', $password);
+        $this->assertRegExp('/[0-9]/', $password);
+        $this->assertRegExp('/[_#@%&]/', $password);
+    }
+
+    /**
+     * Ensures short password generation, where the length is less than the
+     * number of character classes, works properly
+     */
+    function testCreateUnpronouncableShortWithAllClasses()
+    {
+        $password = $this->subject->create(2, 'unpronounceable', '');
+        $this->assertRegExp('/^[a-z0-9_#@%&]{2}$/i', $password);
     }
 
     // {{{ Test cases for creating passwords based on a given login string


### PR DESCRIPTION
 * add comments to code
 * fix random distribution of characters when using classes
 * switch back to mt_rand instead of rand. Use random_int on PHP 7