### PR TITLE
Drop now useless baseinstalldir

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -45,7 +45,7 @@ http://pear.php.net/manual/.
     <file name="Text_Password_Test.php" role="test" />
    </dir> <!-- //tests -->
    <dir name="Text">
-    <file baseinstalldir="Text" name="Password.php" role="php" />
+    <file name="Password.php" role="php" />
    </dir> <!-- /Text -->
   </dir> <!-- / -->
  </contents>


### PR DESCRIPTION
Fixes [#21022](http://pear.php.net/bugs/bug.php?id=21022): Broken PEAR installation