### PR TITLE
fix implode call

### DIFF
--- a/Text/Password.php
+++ b/Text/Password.php
@@ -431,7 +431,7 @@ class Text_Password
 
         shuffle($tmp);
 
-        return implode($tmp, '');
+        return implode('', $tmp);
     }
 
     /**


### PR DESCRIPTION
Failed test with PHP 8
```

1) Text_Password_Test::testCreateFromLoginShuffle
TypeError: implode(): Argument #2 ($array) must be of type ?array, string given

```